### PR TITLE
添加 Dusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Awesome macOS open source Apps
 
 ## System Utility
 
+- [Dusty](https://github.com/yagcioglutoprak/dusty) ![native] - Menu bar disk cleaner with an allowlist-only deletion engine that shows every path before removing anything
+
 - [Pearcleaner](https://github.com/alienator88/Pearcleaner) A free, source-available and fair-code licensed mac app cleaner
 
 
@@ -57,7 +59,6 @@ Awesome macOS open source Apps
 
 [native]: https://img.shields.io/badge/native-D9603E
 [paid]: https://img.shields.io/badge/paid-FFC131?&logoColor=black
-
 
 
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -46,6 +46,8 @@
 
 ## 系统工具
 
+- [Dusty](https://github.com/yagcioglutoprak/dusty) ![native] - 菜单栏磁盘清理工具，采用仅允许列表的删除引擎，删除前会显示每个路径
+
 - [Pearcleaner](https://github.com/alienator88/Pearcleaner) 免费、源码可用、公平代码许可的 Mac 应用清理工具
 
 
@@ -56,7 +58,6 @@
 
 [native]: https://img.shields.io/badge/native-D9603E
 [paid]: https://img.shields.io/badge/paid-FFC131?&logoColor=black
-
 
 
 


### PR DESCRIPTION
Adds Dusty to the System Utility section in both README.md and README_CN.md.\n\nDusty is a native Swift macOS menu bar disk cleaner with an allowlist-only deletion engine. It shows every path before removing anything, so it fits alongside Pearcleaner as an open-source system utility.\n\nKept the English and Chinese files in sync, placed Dusty alphabetically before Pearcleaner, and used the existing native badge format.