### PR TITLE
新增: Maccy 剪贴板管理工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Awesome macOS open source Apps
 
 ## Productivity
 
+- [Maccy](https://github.com/p0deje/Maccy) ![native] Clipboard manager for macOS.
+
 - [RClick](https://github.com/wflixu/RClick) ![native] A Finder extension  for customizing context menu.
 
 - [AIME](https://github.com/wflixu/AIME) ![native] Automatically switch input method for different applications.

--- a/README_CN.md
+++ b/README_CN.md
@@ -16,6 +16,8 @@
 
 ## 效率工具
 
+- [Maccy](https://github.com/p0deje/Maccy) ![native] macOS 剪贴板管理工具。
+
 - [RClick](https://github.com/wflixu/RClick) ![native] Finder 扩展，用于自定义右键菜单。
 
 - [AIME](https://github.com/wflixu/AIME) ![native] 根据不同应用自动切换输入法。


### PR DESCRIPTION
 - Add [Maccy](https://github.com/p0deje/Maccy) to Productivity section in both README and README_CN
  - Maccy 已在英文版和中文版 README 的效率工具分类中列出